### PR TITLE
Make optional react-native-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
   "peerDependenciesMeta": {
     "@types/react": {
       "optional": true
+    },
+    "react-native-svg": {
+      "optional": true
     }
   },
   "publishConfig": {


### PR DESCRIPTION
When using `ubie-icons` on the web, `react-native-svg` is not necessary, so I have specified it as optional.