### PR TITLE
chore: 🤖 remove unnecessary peerdeps settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
   "peerDependenciesMeta": {
     "@types/react": {
       "optional": true
-    },
-    "react-native-svg": {
-      "optional": true
     }
   },
   "publishConfig": {


### PR DESCRIPTION
it is no longer necessary, as native icons are moved to https://github.com/ubie-oss/ubie-icons-native